### PR TITLE
fix a py2 compat issue in neonatal_cortex.py

### DIFF
--- a/lib/python/mirtk/deformable/neonatal_cortex.py
+++ b/lib/python/mirtk/deformable/neonatal_cortex.py
@@ -193,8 +193,11 @@ def output(name_or_func, delete=False):
         Absolute path of output file.
 
     """
-    if isinstance(name_or_func, str): path = name_or_func
-    else:                             path = name_or_func()
+    if callable(name_or_func):
+        path = name_or_func()
+    else:
+        path = name_or_func
+
     if path:
         try:
             yield os.path.abspath(path)


### PR DESCRIPTION
It was testing for "stringiness" with `isinstance(str)`, but this only
works with py3.

Instead, test for "functionness" with `callable(x)`. This was deprecated
in py3.1, but has been undeprecated for py3.2+, so it's safer and
simpler.

https://bugs.python.org/issue10518